### PR TITLE
llog: enable using LLogWriter in a context manager

### DIFF
--- a/llog/llog.py
+++ b/llog/llog.py
@@ -298,3 +298,9 @@ class LLogWriter:
     def close(self):
         if self.logfile:
             self.logfile.close()
+    
+    def __enter__(self):
+        return self
+    
+    def __exit__(self, *exc):
+        self.close()


### PR DESCRIPTION
Auto-closes file on exception - avoids needing to set signal handlers.